### PR TITLE
Update omniauth-oauth2 to 1.7.1

### DIFF
--- a/example/config.ru
+++ b/example/config.ru
@@ -5,7 +5,7 @@ require './app.rb'
 use Rack::Session::Cookie, :secret => 'abc123'
 
 use OmniAuth::Builder do
-  provider :office365, ENV['OFFICE365_APP_ID'], ENV['OFFICE365_APP_SECRET'], :scope => 'https://outlook.office.com/mail.read'
+  provider :office365, ENV['OFFICE365_APP_ID'], ENV['OFFICE365_APP_SECRET'], :scope => 'user.read'
 end
 
 run Sinatra::Application

--- a/example/config.ru
+++ b/example/config.ru
@@ -8,4 +8,6 @@ use OmniAuth::Builder do
   provider :office365, ENV['OFFICE365_APP_ID'], ENV['OFFICE365_APP_SECRET'], :scope => 'user.read'
 end
 
+OmniAuth.config.allowed_request_methods = [:get, :post]
+
 run Sinatra::Application

--- a/omniauth-office365.gemspec
+++ b/omniauth-office365.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w[lib]
   gem.version       = OmniAuth::Office365::VERSION
 
-  gem.add_dependency 'omniauth-oauth2', '~> 1.6.0'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.7.1'
 
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
In order to support omniauth v2.0 we need to upgrade omniauth-oauth2 to v1.7.1.

https://github.com/omniauth/omniauth-oauth2/releases/tag/v1.7.1