### PR TITLE
update omniauth-oauth2 1.8.0

### DIFF
--- a/lib/omniauth-office365/version.rb
+++ b/lib/omniauth-office365/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Office365
-    VERSION = '1.2.0'.freeze
+    VERSION = '1.2.1'.freeze
   end
 end

--- a/omniauth-office365.gemspec
+++ b/omniauth-office365.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w[lib]
   gem.version       = OmniAuth::Office365::VERSION
 
-  gem.add_dependency 'omniauth-oauth2', '~> 1.7.1'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.8.0'
 
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
https://buk.atlassian.net/jira/software/c/projects/FX/boards/532?selectedIssue=FX-914

actualiza omniauth-oauth2 1.8.0




Adjunto CHANGELOG
https://github.com/omniauth/omniauth-oauth2/compare/v1.7.1...v1.8.0

Lo más importante agregado aquí es https://github.com/omniauth/omniauth-oauth2/pull/144 
que resuelve problemas de vulnerabilidad. más información en el PR
